### PR TITLE
fix: frames not being filtered on page load

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -51,4 +51,5 @@ window.Zepto(function ($) {
 
   displayFirstView()
   showFrameContext($('.frame-row.active')[0])
+  filterFrames()
 })


### PR DESCRIPTION
With this change the checkbox now works correctly on page load.