### PR TITLE
fix: normalize all frame `filePath` to posix format

### DIFF
--- a/src/Youch.js
+++ b/src/Youch.js
@@ -166,9 +166,9 @@ class Youch {
   _serializeFrame (frame) {
     return {
       file: frame.fileRelative,
-      filePath: frame.file.startsWith('file:') ? 
-        fileURLToPath(frame.file).replaceAll('\\', '/') : 
-        frame.file,
+      filePath: frame.file.startsWith('file:')
+        ? fileURLToPath(frame.file).replaceAll('\\', '/')
+        : frame.file,
       line: frame.line,
       callee: frame.callee,
       calleeShort: frame.calleeShort,

--- a/src/Youch.js
+++ b/src/Youch.js
@@ -166,7 +166,9 @@ class Youch {
   _serializeFrame (frame) {
     return {
       file: frame.fileRelative,
-      filePath: frame.file.startsWith('file:') ? fileURLToPath(frame.file) : frame.file,
+      filePath: frame.file.startsWith('file:') ? 
+        fileURLToPath(frame.file).replaceAll('\\', '/') : 
+        frame.file,
       line: frame.line,
       callee: frame.callee,
       calleeShort: frame.calleeShort,

--- a/test/youch.spec.mjs
+++ b/test/youch.spec.mjs
@@ -38,7 +38,7 @@ test.group('Youch | ESM', () => {
     youch
       .toJSON()
       .then(({ error }) => {
-        assert.equal(error.frames[0].filePath, __filename)
+        assert.equal(error.frames[0].filePath, __filename.replaceAll('\\', '/'))
         assert.equal(error.frames[0].isNative, false)
         done()
       }).catch(done)


### PR DESCRIPTION
Okay so, I will explain why this modification is required for Windows users : 

I wanted to add the feature of having a relative path rather than absolute path in the Japa error printer. But after investigating I noticed that this feature was already in place! Thanks to the `displayShortPath` property of `youch-terminal`. 
But it doesn't work for Windows : 

![image](https://user-images.githubusercontent.com/8337858/188227619-503592d7-ab4e-4dc7-8d57-17ba7ad5f329.png)


- So the first thing we need to do is to normalize the Youch filePaths, so that they are all Posix. In our case, the filePaths that come out of StackTracey, are in Posix format, even for me who is under Windows. 
The only paths that are not in Posix are the ones coming out of `fileURLToPath`. The separator of the path is platform specific in this case. So that's what's I fixed in this PR

- The second thing, which will be sent in a PR for `youch-terminal`, is to modify this line: 
https://github.com/poppinss/youch-terminal/blob/develop/index.js#L139
  We'll just convert the return of `cwd()`, which is platform specific, to posix format. And also don't use `sep` anymore but just a `/`. 

Thanks to these modifications, I now have a nice relative path in Japa!

![image](https://user-images.githubusercontent.com/8337858/188227370-89703225-bb89-43ce-857d-ce8609174f39.png)

We could have done the opposite, and keep specific platform paths (and thus rather convert the paths of StackTracey). Personally, I prefer that we normalize all this. It makes the code more predictable, I think. If I miss something, let me know

Feel free to ask if it isn't clear ! 👍 
