### PR TITLE
fix: detect node modules frames

### DIFF
--- a/src/Youch.js
+++ b/src/Youch.js
@@ -223,7 +223,7 @@ class Youch {
    * @private
    */
   _isNodeModule (frame) {
-    return (frame.file || '').indexOf('node_modules' + path.sep) > -1
+    return (frame.file || '').indexOf('node_modules/') > -1
   }
 
   /**

--- a/test/youch.spec.js
+++ b/test/youch.spec.js
@@ -125,7 +125,7 @@ test.group('Youch', () => {
     const error = new Error('this is bar')
     const youch = new Youch(error, {})
     const frame = {
-      file: process.platform === 'win32' ? '.\\node_modules\\hello.js' : './node_modules/hello.js'
+      file: './node_modules/hello.js'
     }
     assert.isTrue(youch._isNodeModule(frame))
   })

--- a/test/youch.spec.mjs
+++ b/test/youch.spec.mjs
@@ -130,7 +130,7 @@ test.group('Youch | ESM', () => {
     const error = new Error('this is bar')
     const youch = new Youch(error, {})
     const frame = {
-      file: process.platform === 'win32' ? '.\\node_modules\\hello.js' : './node_modules/hello.js'
+      file: './node_modules/hello.js'
     }
     assert.isTrue(youch._isNodeModule(frame))
   })


### PR DESCRIPTION
Hey ! 
So another fix somewhat related to what I was explaining here:  #46 

The detection of node modules frames was incorrect for windows users, as you can see here : 
![image](https://user-images.githubusercontent.com/8337858/188265768-112e7e53-de68-4152-9172-a23443ed99b4.png)

This is also because StackTracey returns paths in Posix format. So I just fixed that, and now I have the right stack displayed 
![image](https://user-images.githubusercontent.com/8337858/188265810-01ad5812-a094-437c-9980-b9c8f7e46621.png)

( this bug was really really annoying but I never found the time to look at it 😋  ) 
