### PR TITLE
Fix `TypeError: Invalid path string` when path is empty in Bun

### DIFF
--- a/src/Youch.js
+++ b/src/Youch.js
@@ -56,6 +56,10 @@ class Youch {
     } catch {
     }
 
+    if (!path) {
+      return Promise.resolve(null)
+    }
+
     return new Promise((resolve) => {
       fs.readFile(path, 'utf-8', (error, contents) => {
         if (error) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Bun would throw a `TypeError: Invalid path string: can't be empty` when encountering an empty path. This PR addresses and resolves the issue
