### PR TITLE
Fix type of the argument for `toHTML` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare module "youch" {
      * by parsing the stack into frames and getting
      * important info out of it.
      */
-    toHTML(data: Record<string, any>): Promise<string>;
+    toHTML(data?: Record<string, any>): Promise<string>;
   }
 
   export default Youch;


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#50 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

TypeScript type for the argument of the method `toHTML` is incorrect, since the implementation treats it as optional, but the type as required.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
