### PR TITLE
Fix preview width if stack rows are too wide

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -10,7 +10,7 @@ class HttpException extends Error {
   }
 }
 
-function foo () {
+function foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo () {
   const error = new HttpException('Some weird error')
   error.status = 503
   throw error
@@ -19,7 +19,7 @@ function foo () {
 http.createServer((req, res) => {
   let youch = null
   try {
-    foo()
+    foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo()
   } catch (e) {
     youch = new Youch(e, req)
   }

--- a/examples/index.js
+++ b/examples/index.js
@@ -10,7 +10,7 @@ class HttpException extends Error {
   }
 }
 
-function foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo () {
+function foo () {
   const error = new HttpException('Some weird error')
   error.status = 503
   throw error
@@ -19,7 +19,7 @@ function foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofo
 http.createServer((req, res) => {
   let youch = null
   try {
-    foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo()
+    foo()
   } catch (e) {
     youch = new Youch(e, req)
   }

--- a/src/error.compiled.mustache
+++ b/src/error.compiled.mustache
@@ -488,12 +488,13 @@ body {
 
 .error-frames {
   display: flex;
-  flex-direction: row-reverse;
+  flex-wrap: wrap;
+  gap: 40px;
 }
 
 .frame-preview {
   background: #fff;
-  width: 50%;
+  flex: 1 1 400px;
   box-shadow: 0px 0px 9px #d3d3d3;
   height: 100%;
   box-sizing: border-box;
@@ -501,8 +502,7 @@ body {
 }
 
 .frame-stack {
-  margin-right: 40px;
-  flex: 1;
+  flex: 1 1 300px;
   padding: 10px 0;
   box-sizing: border-box;
 }
@@ -632,19 +632,7 @@ code[class*="language-"], pre[class*="language-"] {
   display: none;
 }
 
-@media only screen and (max-width: 970px) {
-  .error-frames {
-    flex-direction: column-reverse;
-  }
 
-  .frame-preview {
-    width: 100%;
-  }
-
-  .frame-stack {
-    width: 100%;
-  }
-}
 
   </style>
 
@@ -665,12 +653,6 @@ code[class*="language-"], pre[class*="language-"] {
       </div>
 
       <div class="error-frames">
-        {{!-- Filled using frontend code, based upon the active frame --}}
-        <div class="frame-preview is-hidden">
-          <div id="frame-file"></div>
-          <div id="frame-code"><pre class="line-numbers"><code class="language-js" id="code-drop"></code></pre></div>
-          <div id="frame-method"></div>
-        </div>
 
         <div class="frame-stack">
           <div class="frames-filter-selector">
@@ -701,6 +683,13 @@ code[class*="language-"], pre[class*="language-"] {
               </div>
             {{/frames}}
           </div>
+        </div>
+
+        {{!-- Filled using frontend code, based upon the active frame --}}
+        <div class="frame-preview is-hidden">
+          <div id="frame-file"></div>
+          <div id="frame-code"><pre class="line-numbers"><code class="language-js" id="code-drop"></code></pre></div>
+          <div id="frame-method"></div>
         </div>
       </div>
     </section>

--- a/src/error.compiled.mustache
+++ b/src/error.compiled.mustache
@@ -499,12 +499,14 @@ body {
   height: 100%;
   box-sizing: border-box;
   overflow: auto;
+  width: 100%;
 }
 
 .frame-stack {
   flex: 1 1 300px;
   padding: 10px 0;
   box-sizing: border-box;
+  width: 100%;
 }
 
 .frames-list {

--- a/static/app.css
+++ b/static/app.css
@@ -87,12 +87,14 @@ body {
   height: 100%;
   box-sizing: border-box;
   overflow: auto;
+  width: 100%;
 }
 
 .frame-stack {
   flex: 1 1 300px;
   padding: 10px 0;
   box-sizing: border-box;
+  width: 100%;
 }
 
 .frames-list {

--- a/static/app.css
+++ b/static/app.css
@@ -76,12 +76,13 @@ body {
 
 .error-frames {
   display: flex;
-  flex-direction: row-reverse;
+  flex-wrap: wrap;
+  gap: 40px;
 }
 
 .frame-preview {
   background: #fff;
-  width: 50%;
+  flex: 1 1 400px;
   box-shadow: 0px 0px 9px #d3d3d3;
   height: 100%;
   box-sizing: border-box;
@@ -89,8 +90,7 @@ body {
 }
 
 .frame-stack {
-  margin-right: 40px;
-  flex: 1;
+  flex: 1 1 300px;
   padding: 10px 0;
   box-sizing: border-box;
 }
@@ -220,16 +220,4 @@ code[class*="language-"], pre[class*="language-"] {
   display: none;
 }
 
-@media only screen and (max-width: 970px) {
-  .error-frames {
-    flex-direction: column-reverse;
-  }
 
-  .frame-preview {
-    width: 100%;
-  }
-
-  .frame-stack {
-    width: 100%;
-  }
-}

--- a/static/error.mustache
+++ b/static/error.mustache
@@ -35,12 +35,6 @@
       </div>
 
       <div class="error-frames">
-        {{!-- Filled using frontend code, based upon the active frame --}}
-        <div class="frame-preview is-hidden">
-          <div id="frame-file"></div>
-          <div id="frame-code"><pre class="line-numbers"><code class="language-js" id="code-drop"></code></pre></div>
-          <div id="frame-method"></div>
-        </div>
 
         <div class="frame-stack">
           <div class="frames-filter-selector">
@@ -71,6 +65,13 @@
               </div>
             {{/frames}}
           </div>
+        </div>
+
+        {{!-- Filled using frontend code, based upon the active frame --}}
+        <div class="frame-preview is-hidden">
+          <div id="frame-file"></div>
+          <div id="frame-code"><pre class="line-numbers"><code class="language-js" id="code-drop"></code></pre></div>
+          <div id="frame-method"></div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

The preview width is too small when the stack rows are wide

Fix https://github.com/poppinss/youch/issues/53

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The goal of this PR is to:

- Resolve layout issues when the stack row text is too wide
- Minor improvements to flex implementation:
  - Applied minimum widths for `frame-preview` and `frame-stack`, grow to fill space
  - Updated `error-frames` to allow `frame-preview` and `frame-stack` to wrap if needed
  - Moved the order of elements within the `error-frames` div so `flex-direction: row-reverse;` is not required 
  - Now using `gap` instead of `margin`
  - Removed media query code, not needed with the above changes

### 🖼️ Screenshots

Before:

https://github.com/poppinss/youch/assets/8052095/5b741a9e-ef52-449f-a67c-279f20a6050c

After:

https://github.com/poppinss/youch/assets/8052095/512a0fa9-194d-4f07-ae8b-a85e88f1fdbf

After - but without the super long method name:

https://github.com/poppinss/youch/assets/8052095/900b44ca-dc9c-4ad7-ac04-0a0313e22e92

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

