### PR TITLE
build: allow node.js 18 in `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Pretty print JavaScript errors on the Web and the Terminal",
   "version": "4.1.0-beta.5",
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=18"
   },
   "type": "module",
   "files": [
@@ -132,5 +132,6 @@
     "@speed-highlight/core": "^1.2.7",
     "cookie": "^1.0.2",
     "youch-core": "^0.3.1"
-  }
+  },
+  "packageManager": "pnpm@9.15.5+sha512.845196026aab1cc3f098a0474b64dfbab2afe7a1b4e91dd86895d8e4aa32a7a6d03049e2d0ad770bbe4de023a7122fb68c1a1d6e0d033c7076085f9d5d4800d4"
 }

--- a/package.json
+++ b/package.json
@@ -128,10 +128,9 @@
   },
   "prettier": "@adonisjs/prettier-config",
   "dependencies": {
-    "@poppinss/dumper": "^0.6.2",
+    "@poppinss/dumper": "^0.6.3",
     "@speed-highlight/core": "^1.2.7",
     "cookie": "^1.0.2",
     "youch-core": "^0.3.1"
-  },
-  "packageManager": "pnpm@9.15.5+sha512.845196026aab1cc3f098a0474b64dfbab2afe7a1b4e91dd86895d8e4aa32a7a6d03049e2d0ad770bbe4de023a7122fb68c1a1d6e0d033c7076085f9d5d4800d4"
+  }
 }


### PR DESCRIPTION
depends on https://github.com/poppinss/dumper/pull/1

currently nitro has dependency on youuch v4 but the engines field for node.js 20+ breaks CI pipelines for users.

I have cross checked that with https://github.com/poppinss/dumper/pull/1, tests pass against youch 4.x.

If you can consider this lowering it will help a lot for adopting youch for us ❤️ 