### PR TITLE
Add @poppinss/colors dependency to satisfy Yarn PnP requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "prettier": "@adonisjs/prettier-config",
   "dependencies": {
+    "@poppinss/colors": "^4.1.4",
     "@poppinss/dumper": "^0.6.3",
     "@speed-highlight/core": "^1.2.7",
     "cookie": "^1.0.2",


### PR DESCRIPTION
### 🔗 Linked issue

#70 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add @poppinss/colors dependency to satisfy Yarn PnP requirements. Yarn in PnP mode doesn't appreciate the import of packages not explicitly stated in the package's dependencies, and per it's verbiage, this makes the import call ambiguous and unsound.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Fixes #70 