### PR TITLE
fix - Support errors without stack trace: Add optional chain to stack trace addEventListeners

### DIFF
--- a/src/public/error_stack/script.js
+++ b/src/public/error_stack/script.js
@@ -45,15 +45,15 @@ function toggleAllFrames() {
 }
 
 onContentLoaded(() => {
-  document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
+  document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
     showFormattedFrames(this)
   })
-  document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
+  document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
     showRawFrames(this)
   })
   document
     .querySelector('#all-frames-toggle input[type="checkbox"]')
-    .addEventListener('change', function () {
+    ?.addEventListener('change', function () {
       toggleAllFrames()
     })
 

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -99,15 +99,15 @@ test.group('Templates', () => {
       }
 
       onContentLoaded(() => {
-        document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
+        document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
           showFormattedFrames(this)
         })
-        document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
+        document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
           showRawFrames(this)
         })
         document
           .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
-          .addEventListener('change', function () {
+          ?.addEventListener('change', function () {
             toggleAllFrames()
           })
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Issue https://github.com/poppinss/youch/issues/73

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There are errors that could not have a stack trace, depending on whether the error would provide valuable information or not when throwing the error. This is why the Error class in JavaScript has an optional stack property.
When trying to use Youch to parse an error without a stack, an error is thrown since it is not supported:

![WhatsApp Image 2025-05-28 at 09 38 25](https://github.com/user-attachments/assets/f43dffb9-4e48-41ee-bd88-8db92f6d1449)

**Solution:** Adding optional chains to stack trace script when `addEventListener` is called.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
