### PR TITLE
fix - Support errors without stack trace and move scripts to the body end

### DIFF
--- a/src/public/error_stack/script.js
+++ b/src/public/error_stack/script.js
@@ -44,31 +44,27 @@ function toggleAllFrames() {
   }
 }
 
-onContentLoaded(() => {
-  document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
-    showFormattedFrames(this)
+document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
+  showFormattedFrames(this)
+})
+document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
+  showRawFrames(this)
+})
+document
+  .querySelector('#all-frames-toggle input[type="checkbox"]')
+  ?.addEventListener('change', function () {
+    toggleAllFrames()
   })
-  document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
-    showRawFrames(this)
+document.querySelectorAll('button[class="stack-frame-location"]').forEach((sfl) => {
+  sfl.addEventListener('click', function (e) {
+    if (e.target.tagName === 'A') {
+      return
+    }
+    toggleFrameSource(e.target.closest('li'))
   })
-  document
-    .querySelector('#all-frames-toggle input[type="checkbox"]')
-    .addEventListener('change', function () {
-      toggleAllFrames()
-    })
-
-  document.querySelectorAll('button[class="stack-frame-location"]').forEach((sfl) => {
-    sfl.addEventListener('click', function (e) {
-      if (e.target.tagName === 'A') {
-        return
-      }
-      toggleFrameSource(e.target.closest('li'))
-    })
-  })
-
-  document.querySelectorAll('button[class="stack-frame-toggle-indicator"]').forEach((sfl) => {
-    sfl.addEventListener('click', function (e) {
-      toggleFrameSource(e.target.closest('li'))
-    })
+})
+document.querySelectorAll('button[class="stack-frame-toggle-indicator"]').forEach((sfl) => {
+  sfl.addEventListener('click', function (e) {
+    toggleFrameSource(e.target.closest('li'))
   })
 })

--- a/src/public/error_stack/script.js
+++ b/src/public/error_stack/script.js
@@ -44,27 +44,29 @@ function toggleAllFrames() {
   }
 }
 
-document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
-  showFormattedFrames(this)
-})
-document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
-  showRawFrames(this)
-})
-document
-  .querySelector('#all-frames-toggle input[type="checkbox"]')
-  ?.addEventListener('change', function () {
-    toggleAllFrames()
+  document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
+    showFormattedFrames(this)
   })
-document.querySelectorAll('button[class="stack-frame-location"]').forEach((sfl) => {
-  sfl.addEventListener('click', function (e) {
-    if (e.target.tagName === 'A') {
-      return
-    }
-    toggleFrameSource(e.target.closest('li'))
+  document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
+    showRawFrames(this)
   })
-})
-document.querySelectorAll('button[class="stack-frame-toggle-indicator"]').forEach((sfl) => {
-  sfl.addEventListener('click', function (e) {
-    toggleFrameSource(e.target.closest('li'))
+  document
+    .querySelector('#all-frames-toggle input[type="checkbox"]')
+    ?.addEventListener('change', function () {
+      toggleAllFrames()
+    })
+
+  document.querySelectorAll('button[class="stack-frame-location"]').forEach((sfl) => {
+    sfl.addEventListener('click', function (e) {
+      if (e.target.tagName === 'A') {
+        return
+      }
+      toggleFrameSource(e.target.closest('li'))
+    })
   })
-})
+
+  document.querySelectorAll('button[class="stack-frame-toggle-indicator"]').forEach((sfl) => {
+    sfl.addEventListener('click', function (e) {
+      toggleFrameSource(e.target.closest('li'))
+    })
+  })

--- a/src/public/header/script.js
+++ b/src/public/header/script.js
@@ -8,9 +8,7 @@ function toggleTheme(input) {
   }
 }
 
-onContentLoaded(() => {
-  document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
-  document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
-    toggleTheme(this)
-  })
+document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
+document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
+  toggleTheme(this)
 })

--- a/src/public/header/script.js
+++ b/src/public/header/script.js
@@ -8,7 +8,7 @@ function toggleTheme(input) {
   }
 }
 
-document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
-document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
-  toggleTheme(this)
-})
+  document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
+  document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
+    toggleTheme(this)
+  })

--- a/src/public/layout/script.js
+++ b/src/public/layout/script.js
@@ -9,12 +9,4 @@ function usesDarkMode() {
   return hasDarkMode
 }
 
-function onContentLoaded(listener) {
-  if (document.readyState !== 'loading') {
-    listener()
-    return
-  }
-  document.addEventListener('DOMContentLoaded', listener)
-}
-
 document.documentElement.classList.add(usesDarkMode() ? 'dark' : 'light')

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -92,11 +92,7 @@ export class Templates {
       scripts.push(`<script id="${name}-script"${cspNonceAttr}>${bucket}</script>`)
     })
 
-    return {
-      styles: `${styles.join('\n')}\n${customInjectedStyles}`,
-      scripts: scripts.join('\n'),
-      globalScript,
-    }
+    return { styles: `${styles.join('\n')}\n${customInjectedStyles}`, scripts: scripts.join('\n'), globalScript }
   }
 
   /**
@@ -214,10 +210,7 @@ export class Templates {
     })
 
     const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
-    return html
-      .replace('<!-- STYLES -->', styles)
-      .replace('<!-- GLOBAL SCRIPT -->', globalScript)
-      .replace('<!-- SCRIPTS -->', scripts)
+    return html.replace('<!-- STYLES -->', styles).replace('<!-- SCRIPTS -->', scripts).replace('<!-- GLOBAL SCRIPT -->', globalScript)
   }
 
   /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -214,8 +214,8 @@ export class Templates {
     })
 
     const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
-    
-    return html.replace('<!-- STYLES -->', styles)
+    return html
+      .replace('<!-- STYLES -->', styles)
       .replace('<!-- SCRIPTS -->', scripts)
       .replace('<!-- GLOBAL SCRIPT -->', globalScript)
   }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -213,13 +213,11 @@ export class Templates {
       },
     })
 
-    const { scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
     const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
     return html
       .replace('<!-- STYLES -->', styles)
       .replace('<!-- GLOBAL SCRIPT -->', globalScript)
       .replace('<!-- SCRIPTS -->', scripts)
-    }
   }
 
   /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -92,7 +92,11 @@ export class Templates {
       scripts.push(`<script id="${name}-script"${cspNonceAttr}>${bucket}</script>`)
     })
 
-    return { styles: `${styles.join('\n')}\n${customInjectedStyles}`, scripts: scripts.join('\n'), globalScript }
+    return {
+      styles: `${styles.join('\n')}\n${customInjectedStyles}`,
+      scripts: scripts.join('\n'),
+      globalScript,
+    }
   }
 
   /**
@@ -210,7 +214,9 @@ export class Templates {
     })
 
     const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
-    return html.replace('<!-- STYLES -->', styles).replace('<!-- SCRIPTS -->', scripts).replace('<!-- GLOBAL SCRIPT -->', globalScript)
+    return html.replace('<!-- STYLES -->', styles)
+      .replace('<!-- SCRIPTS -->', scripts)
+      .replace('<!-- GLOBAL SCRIPT -->', globalScript)
   }
 
   /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -214,6 +214,7 @@ export class Templates {
     })
 
     const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
+    
     return html.replace('<!-- STYLES -->', styles)
       .replace('<!-- SCRIPTS -->', scripts)
       .replace('<!-- GLOBAL SCRIPT -->', globalScript)

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -72,6 +72,7 @@ export class Templates {
      * the end
      */
     let customInjectedStyles: string = ''
+    let globalScript: string = ''
     const styles: string[] = []
     const scripts: string[] = []
     const cspNonceAttr = cspNonce ? ` nonce="${cspNonce}"` : ''
@@ -84,10 +85,18 @@ export class Templates {
       }
     })
     this.#scripts.forEach((bucket, name) => {
+      if (name === 'global') {
+        globalScript = `<script id="${name}-script"${cspNonceAttr}>${bucket}</script>`
+      }
+
       scripts.push(`<script id="${name}-script"${cspNonceAttr}>${bucket}</script>`)
     })
 
-    return { styles: `${styles.join('\n')}\n${customInjectedStyles}`, scripts: scripts.join('\n') }
+    return {
+      styles: `${styles.join('\n')}\n${customInjectedStyles}`,
+      scripts: scripts.join('\n'),
+      globalScript,
+    }
   }
 
   /**
@@ -205,7 +214,12 @@ export class Templates {
     })
 
     const { scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
-    return html.replace('<!-- STYLES -->', styles).replace('<!-- SCRIPTS -->', scripts)
+    const { globalScript, scripts, styles } = this.#getStylesAndScripts(props.cspNonce)
+    return html
+      .replace('<!-- STYLES -->', styles)
+      .replace('<!-- GLOBAL SCRIPT -->', globalScript)
+      .replace('<!-- SCRIPTS -->', scripts)
+    }
   }
 
   /**

--- a/src/templates/layout/main.ts
+++ b/src/templates/layout/main.ts
@@ -34,12 +34,13 @@ export class Layout extends BaseComponent<LayoutProps> {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>${props.title}</title>
         <!-- STYLES -->
-        <!-- SCRIPTS -->
+        <!-- GLOBAL SCRIPT -->
       </head>
       <body>
         <div id="layout">
           ${await props.children()}
         </div>
+        <!-- SCRIPTS -->
       </body>
     </html>`
   }

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -117,11 +117,11 @@ test.group('Templates', () => {
           })
         })
 
-      document.querySelectorAll('button[class=\\"stack-frame-toggle-indicator\\"]').forEach((sfl) => {
-        sfl.addEventListener('click', function (e) {
-          toggleFrameSource(e.target.closest('li'))
-        })
-      })"
+        document.querySelectorAll('button[class=\\"stack-frame-toggle-indicator\\"]').forEach((sfl) => {
+          sfl.addEventListener('click', function (e) {
+            toggleFrameSource(e.target.closest('li'))
+          })
+        })"
     `)
     expect(window.document.querySelector('#error-hint')).toEqual(null)
   })

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -43,10 +43,10 @@ test.group('Templates', () => {
         }
       }
 
-      document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
-      document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
-        toggleTheme(this)
-      })"
+        document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
+        document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
+          toggleTheme(this)
+        })"
     `)
     expect(window.document.querySelector('#errorStack-script')?.textContent?.trim())
       .toMatchInlineSnapshot(`
@@ -96,25 +96,27 @@ test.group('Templates', () => {
         }
       }
 
-      document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
-        showFormattedFrames(this)
-      })
-      document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
-        showRawFrames(this)
-      })
-      document
-        .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
-        ?.addEventListener('change', function () {
-          toggleAllFrames()
+        document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
+          showFormattedFrames(this)
         })
-      document.querySelectorAll('button[class=\\"stack-frame-location\\"]').forEach((sfl) => {
-        sfl.addEventListener('click', function (e) {
-          if (e.target.tagName === 'A') {
-            return
-          }
-          toggleFrameSource(e.target.closest('li'))
+        document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
+          showRawFrames(this)
         })
-      })
+        document
+          .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
+          ?.addEventListener('change', function () {
+            toggleAllFrames()
+          })
+
+        document.querySelectorAll('button[class=\\"stack-frame-location\\"]').forEach((sfl) => {
+          sfl.addEventListener('click', function (e) {
+            if (e.target.tagName === 'A') {
+              return
+            }
+            toggleFrameSource(e.target.closest('li'))
+          })
+        })
+
       document.querySelectorAll('button[class=\\"stack-frame-toggle-indicator\\"]').forEach((sfl) => {
         sfl.addEventListener('click', function (e) {
           toggleFrameSource(e.target.closest('li'))

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -43,11 +43,9 @@ test.group('Templates', () => {
         }
       }
 
-      onContentLoaded(() => {
-        document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
-        document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
-          toggleTheme(this)
-        })
+      document.querySelector('#toggle-theme-checkbox').checked = usesDarkMode()
+      document.querySelector('#toggle-theme-checkbox').addEventListener('change', function () {
+        toggleTheme(this)
       })"
     `)
     expect(window.document.querySelector('#errorStack-script')?.textContent?.trim())
@@ -98,32 +96,28 @@ test.group('Templates', () => {
         }
       }
 
-      onContentLoaded(() => {
-        document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
-          showFormattedFrames(this)
+      document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
+        showFormattedFrames(this)
+      })
+      document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
+        showRawFrames(this)
+      })
+      document
+        .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
+        ?.addEventListener('change', function () {
+          toggleAllFrames()
         })
-        document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
-          showRawFrames(this)
+      document.querySelectorAll('button[class=\\"stack-frame-location\\"]').forEach((sfl) => {
+        sfl.addEventListener('click', function (e) {
+          if (e.target.tagName === 'A') {
+            return
+          }
+          toggleFrameSource(e.target.closest('li'))
         })
-        document
-          .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
-          .addEventListener('change', function () {
-            toggleAllFrames()
-          })
-
-        document.querySelectorAll('button[class=\\"stack-frame-location\\"]').forEach((sfl) => {
-          sfl.addEventListener('click', function (e) {
-            if (e.target.tagName === 'A') {
-              return
-            }
-            toggleFrameSource(e.target.closest('li'))
-          })
-        })
-
-        document.querySelectorAll('button[class=\\"stack-frame-toggle-indicator\\"]').forEach((sfl) => {
-          sfl.addEventListener('click', function (e) {
-            toggleFrameSource(e.target.closest('li'))
-          })
+      })
+      document.querySelectorAll('button[class=\\"stack-frame-toggle-indicator\\"]').forEach((sfl) => {
+        sfl.addEventListener('click', function (e) {
+          toggleFrameSource(e.target.closest('li'))
         })
       })"
     `)


### PR DESCRIPTION
### 🔗 Linked issue

Issue: https://github.com/poppinss/youch/issues/78

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. There are errors that could not have a stack trace, depending on whether the error would provide valuable information or not when throwing the error. This is why the `Error` class in JavaScript has an optional `stack` property.
  When trying to use Youch to parse an error without a stack, an error is thrown since it is not supported:
  
  ![WhatsApp Image 2025-05-28 at 09 38 25](https://github.com/user-attachments/assets/f43dffb9-4e48-41ee-bd88-8db92f6d1449)

  **Solution**: Adding optional chains to stack trace script when `addEventListener` is called.

2. It is not necessary to listen to `onContentLoaded` event to execute listeners if the scripts are at the end of the `body`. When the page is rendered, if these scripts are at the end of the `body`, the HTML elements they refer to will already be available. The page rendering respects the order of HTML elements while rendering.

**Note:** Global scripts must be maintained at the beginning of the HTML.

### 📝 Checklist

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
