### PR TITLE
fix(template): wrong scollbar color when page and browser theme mismatch

### DIFF
--- a/src/public/layout/style.css
+++ b/src/public/layout/style.css
@@ -133,6 +133,8 @@
   --generator-label-fg-color: #7b3814;
   --blob-label-fg-color: #7b3814;
   --unknown-label-fg-color: #7b3814;
+
+  color-scheme: only light;
 }
 
 html.dark {
@@ -255,6 +257,8 @@ html.dark {
   --generator-label-fg-color: #94e2d5;
   --blob-label-fg-color: #94e2d5;
   --unknown-label-fg-color: #94e2d5;
+
+  color-scheme: dark;
 }
 
 html,


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

<img width="852" height="557" alt="QQ_1761980724952" src="https://github.com/user-attachments/assets/bd2c45b7-e3a3-4f16-b6d9-b8d1d889caf3" />

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fix scrollbar color when page and browser theme mismatch.

Better to merge after https://github.com/poppinss/dumper/pull/2 merged.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
