### PR TITLE
feat: add stack trace to copy button

### DIFF
--- a/src/public/error_info/script.js
+++ b/src/public/error_info/script.js
@@ -1,6 +1,6 @@
 function copyErrorMessage(button) {
   const errorText = button.dataset.errorText;
-  
+
   navigator.clipboard.writeText(errorText)
     .then(() => {
       button.classList.add('copied');

--- a/src/public/error_info/style.css
+++ b/src/public/error_info/style.css
@@ -65,16 +65,9 @@ html.dark {
   color: var(--links-fg);
 }
 
-.copy-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+#copy-error-btn {
   margin-left: auto;
   flex-shrink: 0;
-}
-
-#copy-error-btn,
-#copy-stacktrace-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -93,36 +86,21 @@ html.dark {
   transition: all 0.2s ease;
 }
 
-#copy-error-btn svg,
-#copy-stacktrace-btn svg {
+#copy-error-btn svg {
   width: 18px;
   height: 18px;
 }
 
-#copy-stacktrace-btn {
-  gap: 5px;
-  padding: 4px 10px 6px 8px;
-}
-
-#copy-stacktrace-btn span {
-  font-size: 13px;
-  line-height: 1;
-  white-space: nowrap;
-}
-
-#copy-error-btn:hover,
-#copy-stacktrace-btn:hover {
+#copy-error-btn:hover {
   background: var(--copy-button-active-bg);
   color: var(--title-fg);
 }
 
-#copy-error-btn:active,
-#copy-stacktrace-btn:active {
+#copy-error-btn:active {
   transform: scale(0.95);
 }
 
-#copy-error-btn.copied::after,
-#copy-stacktrace-btn.copied::after {
+#copy-error-btn.copied::after {
   content: 'Copied';
   position: absolute;
   top: -30px;

--- a/src/public/error_info/style.css
+++ b/src/public/error_info/style.css
@@ -65,11 +65,19 @@ html.dark {
   color: var(--links-fg);
 }
 
-#copy-error-btn {
+.copy-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+#copy-error-btn,
+#copy-stacktrace-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: auto;
   position: relative;
   cursor: pointer;
 
@@ -85,21 +93,36 @@ html.dark {
   transition: all 0.2s ease;
 }
 
-#copy-error-btn svg {
+#copy-error-btn svg,
+#copy-stacktrace-btn svg {
   width: 18px;
   height: 18px;
 }
 
-#copy-error-btn:hover {
+#copy-stacktrace-btn {
+  gap: 5px;
+  padding: 4px 10px 6px 8px;
+}
+
+#copy-stacktrace-btn span {
+  font-size: 13px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+#copy-error-btn:hover,
+#copy-stacktrace-btn:hover {
   background: var(--copy-button-active-bg);
   color: var(--title-fg);
 }
 
-#copy-error-btn:active {
+#copy-error-btn:active,
+#copy-stacktrace-btn:active {
   transform: scale(0.95);
 }
 
-#copy-error-btn.copied::after {
+#copy-error-btn.copied::after,
+#copy-stacktrace-btn.copied::after {
   content: 'Copied';
   position: absolute;
   top: -30px;

--- a/src/public/error_info/style.css
+++ b/src/public/error_info/style.css
@@ -66,11 +66,10 @@ html.dark {
 }
 
 #copy-error-btn {
-  margin-left: auto;
-  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-left: auto;
   position: relative;
   cursor: pointer;
 

--- a/src/templates/error_info/main.ts
+++ b/src/templates/error_info/main.ts
@@ -80,14 +80,14 @@ export class ErrorInfo extends BaseComponent<ErrorInfoProps> {
             <span>${ERROR_ICON_SVG}</span>
             <span>${htmlEscape(props.error.message)}</span>
             <button
-                id="copy-error-btn"
-                data-error-text="${htmlAttributeEscape(stacktraceText)}"
-                onclick="copyErrorMessage(this)"
-                title="Copy error with stack trace"
-                aria-label="Copy error with stack trace to clipboard"
-              >
-                ${COPY_ICON_SVG}
-              </button>
+              id="copy-error-btn"
+              data-error-text="${htmlAttributeEscape(stacktraceText)}"
+              onclick="copyErrorMessage(this)"
+              title="Copy error with stack trace"
+              aria-label="Copy error with stack trace to clipboard"
+            >
+              ${COPY_ICON_SVG}
+            </button>
           </h2>
           ${
             props.error.hint

--- a/src/templates/error_info/main.ts
+++ b/src/templates/error_info/main.ts
@@ -10,13 +10,40 @@
 import { BaseComponent } from '../../component.js'
 import { publicDirURL } from '../../public_dir.js'
 import { wordWrap, colors, htmlEscape } from '../../helpers.js'
-import type { ErrorInfoProps } from '../../types.js'
+import type { ErrorInfoProps, ParsedError } from '../../types.js'
 
 const ERROR_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="24" height="24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 7v6m0 4.01.01-.011M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z"/></svg>`
 
 const HINT_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="24" height="24" fill="none"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 2-1 1M3 2l1 1m17 13-1-1M3 16l1-1m5 3h6m-5 3h4M12 3C8 3 5.952 4.95 6 8c.023 1.487.5 2.5 1.5 3.5S9 13 9 15h6c0-2 .5-2.5 1.5-3.5h0c1-1 1.477-2.013 1.5-3.5.048-3.05-2-5-6-5Z"/></svg>`
 
 const COPY_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"  stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7m0 2.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667z" /><path d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1" /></svg>`
+
+/**
+ * Builds a copyable text from the parsed error including
+ * the error message and the full stack trace.
+ */
+function buildErrorWithStacktrace(error: ParsedError): string {
+  const cwd = process.cwd()
+  const lines: string[] = []
+
+  lines.push(`${error.name}: ${error.message}`)
+
+  if (error.hint) {
+    lines.push(`Hint: ${error.hint.replace(/(<([^>]+)>)/gi, '')}`)
+  }
+
+  if (error.frames.length > 0) {
+    lines.push('')
+    lines.push('Stack trace:')
+    for (const frame of error.frames) {
+      const fileName = frame.fileName?.replace(`${cwd}/`, '') || '<anonymous>'
+      const func = frame.functionName ? `at ${frame.functionName} ` : 'at '
+      lines.push(`  ${func}(${fileName}:${frame.lineNumber}:${frame.columnNumber})`)
+    }
+  }
+
+  return lines.join('\n')
+}
 
 function htmlAttributeEscape(value: string): string {
   return value
@@ -40,6 +67,8 @@ export class ErrorInfo extends BaseComponent<ErrorInfoProps> {
    * web view
    */
   async toHTML(props: ErrorInfoProps): Promise<string> {
+    const stacktraceText = buildErrorWithStacktrace(props.error)
+
     return `<section>
       <h4 id="error-name">${htmlEscape(props.error.name)}</h4>
       <h1 id="error-title">${htmlEscape(props.title)}</h1>
@@ -50,15 +79,28 @@ export class ErrorInfo extends BaseComponent<ErrorInfoProps> {
           <h2 id="error-message">
             <span>${ERROR_ICON_SVG}</span>
             <span>${htmlEscape(props.error.message)}</span>
-            <button
-              id="copy-error-btn"
-              data-error-text="${htmlAttributeEscape(`${props.error.name}: ${props.error.message}`)}"
-              onclick="copyErrorMessage(this)"
-              title="Copy error message"
-              aria-label="Copy error message to clipboard"
-            >
-              ${COPY_ICON_SVG}
-            </button>
+            <div class="copy-actions">
+
+              <button
+                id="copy-error-btn"
+                data-error-text="${htmlAttributeEscape(`${props.error.name}: ${props.error.message}`)}"
+                onclick="copyErrorMessage(this)"
+                title="Copy error message"
+                aria-label="Copy error message to clipboard"
+              >
+                ${COPY_ICON_SVG}
+              </button>
+              <button
+                id="copy-stacktrace-btn"
+                data-error-text="${htmlAttributeEscape(stacktraceText)}"
+                onclick="copyErrorMessage(this)"
+                title="Copy with stack trace"
+                aria-label="Copy error with stack trace"
+              >
+                ${COPY_ICON_SVG}
+                <span>Copy with stack trace</span>
+              </button>
+            </div>
           </h2>
           ${
             props.error.hint

--- a/src/templates/error_info/main.ts
+++ b/src/templates/error_info/main.ts
@@ -79,28 +79,15 @@ export class ErrorInfo extends BaseComponent<ErrorInfoProps> {
           <h2 id="error-message">
             <span>${ERROR_ICON_SVG}</span>
             <span>${htmlEscape(props.error.message)}</span>
-            <div class="copy-actions">
-
-              <button
+            <button
                 id="copy-error-btn"
-                data-error-text="${htmlAttributeEscape(`${props.error.name}: ${props.error.message}`)}"
-                onclick="copyErrorMessage(this)"
-                title="Copy error message"
-                aria-label="Copy error message to clipboard"
-              >
-                ${COPY_ICON_SVG}
-              </button>
-              <button
-                id="copy-stacktrace-btn"
                 data-error-text="${htmlAttributeEscape(stacktraceText)}"
                 onclick="copyErrorMessage(this)"
-                title="Copy with stack trace"
-                aria-label="Copy error with stack trace"
+                title="Copy error with stack trace"
+                aria-label="Copy error with stack trace to clipboard"
               >
                 ${COPY_ICON_SVG}
-                <span>Copy with stack trace</span>
               </button>
-            </div>
           </h2>
           ${
             props.error.hint


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
With the rise of agents, copying the error with the stack trace can be more relevant so the agent has more context when we paste the error to it.

This PR add the stack trace in the copy button

https://github.com/user-attachments/assets/cc632596-c904-4e8d-9b39-7079857e8209


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion. (no issue)
- [x] I have updated the documentation accordingly. (not needed)
