### PR TITLE
Support errors without stack trace 

### DIFF
--- a/src/public/error_stack/script.js
+++ b/src/public/error_stack/script.js
@@ -44,15 +44,15 @@ function toggleAllFrames() {
   }
 }
 
-document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
+document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
   showFormattedFrames(this)
 })
-document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
+document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
   showRawFrames(this)
 })
 document
   .querySelector('#all-frames-toggle input[type="checkbox"]')
-  .addEventListener('change', function () {
+  ?.addEventListener('change', function () {
     toggleAllFrames()
   })
 

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -96,15 +96,15 @@ test.group('Templates', () => {
         }
       }
 
-      document.querySelector('#formatted-frames-toggle').addEventListener('click', function () {
+      document.querySelector('#formatted-frames-toggle')?.addEventListener('click', function () {
         showFormattedFrames(this)
       })
-      document.querySelector('#raw-frames-toggle').addEventListener('click', function () {
+      document.querySelector('#raw-frames-toggle')?.addEventListener('click', function () {
         showRawFrames(this)
       })
       document
         .querySelector('#all-frames-toggle input[type=\\"checkbox\\"]')
-        .addEventListener('change', function () {
+        ?.addEventListener('change', function () {
           toggleAllFrames()
         })
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/poppinss/youch/issues/78

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Some errors may not include a stack trace, depending on whether the error provides valuable information when thrown. This is why the stack property on JavaScript's Error class is optional. When using `Youch` to parse an error without a stack trace, an error is thrown because this case is not supported:

<img width="655" height="106" alt="image" src="https://github.com/user-attachments/assets/b2d20f15-601d-4020-b272-0c6c550bf9fe" />

**Fix**: Add optional chaining (?.) in the stack trace script so that `addEventListener` is not called when the target element does not exist.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
