### PR TITLE
Replace inline onclick with addEventListener on copy button

### DIFF
--- a/src/public/error_info/script.js
+++ b/src/public/error_info/script.js
@@ -11,3 +11,8 @@ function copyErrorMessage(button) {
       setTimeout(() => button.classList.remove('copied'), 2000);
     });
 }
+
+document.getElementById('copy-error-btn')
+  ?.addEventListener('click', function () {
+    copyErrorMessage(this);
+  });

--- a/src/templates/error_info/main.ts
+++ b/src/templates/error_info/main.ts
@@ -82,7 +82,6 @@ export class ErrorInfo extends BaseComponent<ErrorInfoProps> {
             <button
               id="copy-error-btn"
               data-error-text="${htmlAttributeEscape(stacktraceText)}"
-              onclick="copyErrorMessage(this)"
               title="Copy error with stack trace"
               aria-label="Copy error with stack trace to clipboard"
             >

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -31,6 +31,14 @@ test.group('Templates', () => {
     expect(window.document.querySelector('#error-message')?.textContent?.trim()).toEqual(
       'Something went wrong'
     )
+    expect(window.document.querySelector('#errorInfo-script')?.textContent?.trim()).toEqual(
+      expect.stringContaining(
+        "document.getElementById('copy-error-btn')\n" +
+          "  ?.addEventListener('click', function () {\n" +
+          '    copyErrorMessage(this);\n' +
+          '  });'
+      )
+    )
     expect(window.document.querySelector('#header-script')?.textContent?.trim())
       .toMatchInlineSnapshot(`
       "function toggleTheme(input) {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#90

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The copy button (`#copy-error-btn`) is silently blocked when the application uses a strict Content Security Policy with a nonce.

The button was generated with an inline `onclick` attribute:

```html
<button
  id="copy-error-btn"
  onclick="copyErrorMessage(this)"
  ...
>
```

CSP's script-src directive with a nonce automatically ignores 'unsafe-inline', even if explicitly listed in the policy. Inline event handler attributes like onclick are treated as unsafe-inline and are always blocked when a nonce is present, regardless of whether the nonce is correctly applied to <script> tags.

This fix removes the `onclick` attribute from the template and registers the listener via `addEventListener` inside `script.js`, which is already injected with the CSP nonce.

#### Before

https://github.com/user-attachments/assets/4b81815f-6892-4e8f-872d-7b6c612b05e0

#### After

https://github.com/user-attachments/assets/f3eda7dd-4986-4d28-bc3d-acaddf7cbd4d

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
