### PR TITLE
* improvement: add webstorm as supported editor for error stack view

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ You can specify which code editor to use via the `ide` option. Following is the 
 - emacs
 - sublime
 - phpstorm
+- webstorm
 - atom
 - vscode
 

--- a/src/templates/error_stack/main.ts
+++ b/src/templates/error_stack/main.ts
@@ -30,6 +30,7 @@ const EDITORS: Record<string, string> = {
   emacs: 'emacs://open?url=file://%f&line=%l',
   sublime: 'subl://open?url=file://%f&line=%l',
   phpstorm: 'phpstorm://open?file=%f&line=%l',
+  webstorm: 'webstorm://open?file=%f&line=%l',
   atom: 'atom://core/open/file?filename=%f&line=%l',
   vscode: 'vscode://file/%f:%l',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export type YouchHTMLOptions = {
    * - emacs
    * - sublime
    * - phpstorm
+   * - webstorm
    * - atom
    * - vscode
    *


### PR DESCRIPTION
### 🔗 Linked issue

[(https://github.com/poppinss/youch/issues/91)](https://github.com/poppinss/youch/issues/91)


### ❓ Type of change



- [X] 👌 Enhancement (improving an existing functionality like performance)
- [X] ✨ New feature (a non-breaking change that adds functionality)


### 📚 Description

Added webstorm as editor. I confirmed both links like phpstorm and webstorm open the same in the respective editor.

I have read the contrubution guide, if your eally want to add these trheee lines yourselve, feel free, but I think this change can help out a lot even though it is so very small

All the love! <3 

### 📝 Checklist

- [X] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
